### PR TITLE
Make schema() possibly reentrant

### DIFF
--- a/lib/DBICx/Sugar.pm
+++ b/lib/DBICx/Sugar.pm
@@ -44,10 +44,12 @@ sub add_schema_to_config {
 }
 
 sub schema {
-    my ($name) = @_;
+    my ( $name, $schema_cfg ) = @_;
+
     my $cfg = config();
 
     # We weren't asked for a specific name
+    # try to get one from the default config
     if (not defined $name) {
         my @names = keys %{$cfg}
             or croak("No schemas are configured");
@@ -58,6 +60,12 @@ sub schema {
 
     my $options = $cfg->{$name}
         or croak("The schema $name is not configured");
+
+    # Schema specific configuration from the user
+    if ($schema_cfg) {
+        # Just return a new schema and do not save it
+        return _create_schema( $name, $schema_cfg );
+    }
 
     # Return existing schemas, either by name
     return $_schemas->{$name} if $_schemas->{$name};

--- a/lib/DBICx/Sugar.pm
+++ b/lib/DBICx/Sugar.pm
@@ -56,11 +56,11 @@ sub schema {
         $name = @names == 1 ? $names[0] : 'default';
     }
 
-    # Return existing schemas, either by name
-    return $_schemas->{$name} if $_schemas->{$name};
-
     my $options = $cfg->{$name}
         or croak("The schema $name is not configured");
+
+    # Return existing schemas, either by name
+    return $_schemas->{$name} if $_schemas->{$name};
 
     # Or by alias
     if ( my $alias = $options->{alias} ) {

--- a/lib/DBICx/Sugar.pm
+++ b/lib/DBICx/Sugar.pm
@@ -56,17 +56,34 @@ sub schema {
         $name = @names == 1 ? $names[0] : 'default';
     }
 
+    # Return existing schemas, either by name
     return $_schemas->{$name} if $_schemas->{$name};
 
     my $options = $cfg->{$name}
         or croak("The schema $name is not configured");
 
+    # Or by alias
     if ( my $alias = $options->{alias} ) {
         $options = $cfg->{$alias}
             or croak("The schema alias $alias does not exist in the config");
         return $_schemas->{$alias} if $_schemas->{$alias};
     }
 
+    # Create schema
+    my $schema = _create_schema( $name, $options );
+
+    return $_schemas->{$name} = $schema;
+}
+
+sub resultset {
+    my ($rset_name) = @_;
+    return schema()->resultset($rset_name);
+}
+
+sub rset { goto &resultset }
+
+sub _create_schema {
+    my ( $name, $options ) = @_;
     my @conn_info = $options->{connect_info}
         ? @{$options->{connect_info}}
         : @$options{qw(dsn user password options)};
@@ -104,15 +121,8 @@ sub schema {
         $schema = DBIx::Class::Schema::Loader->connect(@conn_info);
     }
 
-    return $_schemas->{$name} = $schema;
+    return $schema;
 }
-
-sub resultset {
-    my ($rset_name) = @_;
-    return schema()->resultset($rset_name);
-}
-
-sub rset { goto &resultset }
 
 # ABSTRACT: Just some syntax sugar for DBIx::Class
 


### PR DESCRIPTION
[This is also under my Pull Request Challenge, extending the work of Dancer2-Plugin-DBIC to this.]

You can consider this "Step 3 out of 4".

The `schema` method is not flexible enough and requires setting the config (only allowed once) and they are all cached afterwards. This leads to complications, such as GH #12 in Dancer2-Plugin-DBIC.

This change allows it to also accept another argument for local configuration, bypassing reading the global configurations and does not cache the resulting schema. This should be useful for testing, as well as more flexible usage.

This is based on #4, so that will need to be merged first.

This includes a test for it as well.